### PR TITLE
Add support for context is name_get()

### DIFF
--- a/report_aeroo/ExtraFunctions.py
+++ b/report_aeroo/ExtraFunctions.py
@@ -286,8 +286,10 @@ class ExtraFunctions(object):
 
     def _get_name(self, obj, context=None):
         if isinstance(obj, models.Model):
-            if context:
-                return obj.with_context(context).name_get()[0][1]
+            if context and isinstance(context, dict):
+                new_context = obj._context.copy()
+                new_context.update(context)
+                return obj.with_context(new_context).name_get()[0][1]
             else:
                 return obj.name_get()[0][1]
         return ''

--- a/report_aeroo/ExtraFunctions.py
+++ b/report_aeroo/ExtraFunctions.py
@@ -284,9 +284,12 @@ class ExtraFunctions(object):
         exec expr in localspace
         return localspace['value_list']
 
-    def _get_name(self, obj):
+    def _get_name(self, obj, context=None):
         if isinstance(obj, models.Model):
-            return obj.name_get()[0][1]
+            if context:
+                return obj.with_context(context).name_get()[0][1]
+            else:
+                return obj.name_get()[0][1]
         return ''
 
     def _get_label(self, obj, field):


### PR DESCRIPTION
This small feature is quite usefull, because some name_get() on importants objects such as res.partner and product.product have options that are set via the context, see odoo/addons/product/product.py line 1008 or odoo/openerp/addons/base/res/res_partner.py line 594. I already use this patch in production.