### PR TITLE
8.0 Fix bug #3 : Export of translation files now works

### DIFF
--- a/report_aeroo/translate.py
+++ b/report_aeroo/translate.py
@@ -22,32 +22,31 @@
 
 import os
 import logging
-import openerp.pooler as pooler
 import openerp.tools as tools
-from openerp.tools.translate import trans_parse_rml, trans_parse_xsl, trans_parse_view
+from openerp.tools.translate import trans_parse_rml, trans_parse_xsl, trans_parse_view, _extract_translatable_qweb_terms
 import fnmatch
 from os.path import join
 from lxml import etree
 from openerp.tools import misc
-from openerp.tools.misc import UpdateableStr
 from openerp.tools import osutil
 from babel.messages import extract
+import openerp
 
 _logger = logging.getLogger(__name__)
 
 WEB_TRANSLATION_COMMENT = "openerp-web"
+ENGLISH_SMALL_WORDS = set("as at by do go if in me no of ok on or to up us we".split())
+
 
 def extend_trans_generate(lang, modules, cr):
     dbname = cr.dbname
 
-    pool = pooler.get_pool(dbname)
-    trans_obj = pool.get('ir.translation')
-    model_data_obj = pool.get('ir.model.data')
+    registry = openerp.registry(dbname)
+    trans_obj = registry['ir.translation']
+    model_data_obj = registry['ir.model.data']
     uid = 1
-    l = pool.models.items()
-    l.sort()
 
-    query = 'SELECT name, model, res_id, module'    \
+    query = 'SELECT name, model, res_id, module' \
             '  FROM ir_model_data'
 
     query_models = """SELECT m.id, m.model, imd.module
@@ -67,41 +66,64 @@ def extend_trans_generate(lang, modules, cr):
 
     cr.execute(query, query_param)
 
-    _to_translate = []
+    _to_translate = set()
     def push_translation(module, type, name, id, source, comments=None):
-        tuple = (module, source, name, id, type, comments or [])
         # empty and one-letter terms are ignored, they probably are not meant to be
         # translated, and would be very hard to translate anyway.
         if not source or len(source.strip()) <= 1:
-            _logger.debug("Ignoring empty or 1-letter source term: %r", tuple)
             return
-        if tuple not in _to_translate:
-            _to_translate.append(tuple)
+
+        tnx = (module, source, name, id, type, tuple(comments or ()))
+        _to_translate.add(tnx)
 
     def encode(s):
         if isinstance(s, unicode):
             return s.encode('utf8')
         return s
 
+    def push(mod, type, name, res_id, term):
+        term = (term or '').strip()
+        if len(term) > 2 or term in ENGLISH_SMALL_WORDS:
+            push_translation(mod, type, name, res_id, term)
+
+    def get_root_view(xml_id):
+        view = model_data_obj.xmlid_to_object(cr, uid, xml_id)
+        if view:
+            while view.mode != 'primary':
+                view = view.inherit_id
+        xml_id = view.get_external_id(cr, uid).get(view.id, xml_id)
+        return xml_id
+
     for (xml_name,model,res_id,module) in cr.fetchall():
         module = encode(module)
         model = encode(model)
         xml_name = "%s.%s" % (module, encode(xml_name))
 
-        if not pool.get(model):
+        if model not in registry:
             _logger.error("Unable to find object %r", model)
             continue
 
-        exists = pool.get(model).exists(cr, uid, res_id)
-        if not exists:
+        Model = registry[model]
+        if not Model._translate:
+            # explicitly disabled
+            continue
+
+        obj = Model.browse(cr, uid, res_id)
+        if not obj.exists():
             _logger.warning("Unable to find object %r with id %d", model, res_id)
             continue
-        obj = pool.get(model).browse(cr, uid, res_id)
 
         if model=='ir.ui.view':
             d = etree.XML(encode(obj.arch))
-            for t in trans_parse_view(d):
-                push_translation(module, 'view', encode(obj.model), 0, t)
+            if obj.type == 'qweb':
+                view_id = get_root_view(xml_name)
+                push_qweb = lambda t,l: push(module, 'view', 'website', view_id, t)
+                _extract_translatable_qweb_terms(d, push_qweb)
+            else:
+                push_view = lambda t,l: push(module, 'view', obj.model, xml_name, t)
+                trans_parse_view(d, push_view)
+        elif model=='ir.actions.wizard':
+            pass # TODO Can model really be 'ir.actions.wizard' ?
 
         elif model=='ir.model.fields':
             try:
@@ -109,8 +131,9 @@ def extend_trans_generate(lang, modules, cr):
             except AttributeError, exc:
                 _logger.error("name error in %s: %s", xml_name, str(exc))
                 continue
-            objmodel = pool.get(obj.model)
-            if not objmodel or not field_name in objmodel._columns:
+            objmodel = registry.get(obj.model)
+            if (objmodel is None or field_name not in objmodel._columns
+                    or not objmodel._translate):
                 continue
             field_def = objmodel._columns[field_name]
 
@@ -168,14 +191,17 @@ def extend_trans_generate(lang, modules, cr):
                     except (IOError, etree.XMLSyntaxError):
                         _logger.exception("couldn't export translation for report %s %s %s", name, report_type, fname)
 
-        for field_name,field_def in obj._table._columns.items():
+        for field_name, field_def in obj._columns.items():
+            if model == 'ir.model' and field_name == 'name' and obj.name == obj.model:
+                # ignore model name if it is the technical one, nothing to translate
+                continue
             if field_def.translate:
                 name = model + "," + field_name
                 try:
-                    trad = getattr(obj, field_name) or ''
+                    term = obj[field_name] or ''
                 except:
-                    trad = ''
-                push_translation(module, 'model', name, xml_name, encode(trad))
+                    term = ''
+                push_translation(module, 'model', name, xml_name, encode(term))
 
         # End of data for ir.model.data query results
 
@@ -196,13 +222,13 @@ def extend_trans_generate(lang, modules, cr):
             constraints = getattr(cls, '_local_' + cons_type, [])
             for constraint in constraints:
                 push_constraint_msg(module, term_type, model._name, constraint[msg_pos])
-            
-    for (_, model, module) in cr.fetchall():
-        model_obj = pool.get(model)
 
-        if not model_obj:
+    for (_, model, module) in cr.fetchall():
+        if model not in registry:
             _logger.error("Unable to find object %r", model)
             continue
+
+        model_obj = registry[model]
 
         if model_obj._constraints:
             push_local_constraints(module, model_obj, 'constraints')
@@ -210,49 +236,29 @@ def extend_trans_generate(lang, modules, cr):
         if model_obj._sql_constraints:
             push_local_constraints(module, model_obj, 'sql_constraints')
 
-    def get_module_from_path(path, mod_paths=None):
-        if not mod_paths:
-            # First, construct a list of possible paths
-            def_path = os.path.abspath(os.path.join(tools.config['root_path'], 'addons'))     # default addons path (base)
-            ad_paths= map(lambda m: os.path.abspath(m.strip()),tools.config['addons_path'].split(','))
-            mod_paths=[def_path]
-            for adp in ad_paths:
-                mod_paths.append(adp)
-                if not os.path.isabs(adp):
-                    mod_paths.append(adp)
-                elif adp.startswith(def_path):
-                    mod_paths.append(adp[len(def_path)+1:])
-        for mp in mod_paths:
-            if path.startswith(mp) and (os.path.dirname(path) != mp):
-                path = path[len(mp)+1:]
-                return path.split(os.path.sep)[0]
-        return 'base'   # files that are not in a module are considered as being in 'base' module
+    installed_modules = map(
+        lambda m: m['name'],
+        registry['ir.module.module'].search_read(cr, uid, [('state', '=', 'installed')], fields=['name']))
 
-    modobj = pool.get('ir.module.module')
-    installed_modids = modobj.search(cr, uid, [('state', '=', 'installed')])
-    installed_modules = map(lambda m: m['name'], modobj.read(cr, uid, installed_modids, ['name']))
-
-    root_path = os.path.join(tools.config['root_path'], 'addons')
-
-    apaths = map(os.path.abspath, map(str.strip, tools.config['addons_path'].split(',')))
-    if root_path in apaths:
-        path_list = apaths
-    else :
-        path_list = [root_path,] + apaths
-
+    path_list = list(openerp.modules.module.ad_paths)
     # Also scan these non-addon paths
     for bin_path in ['osv', 'report' ]:
         path_list.append(os.path.join(tools.config['root_path'], bin_path))
 
-    _logger.debug("Scanning modules at paths: ", path_list)
+    _logger.debug("Scanning modules at paths: %s", path_list)
 
-    mod_paths = []
+    def get_module_from_path(path):
+        for mp in path_list:
+            if path.startswith(mp) and os.path.dirname(path) != mp:
+                path = path[len(mp)+1:]
+                return path.split(os.path.sep)[0]
+        return 'base' # files that are not in a module are considered as being in 'base' module
 
     def verified_module_filepaths(fname, path, root):
         fabsolutepath = join(root, fname)
         frelativepath = fabsolutepath[len(path):]
         display_path = "addons%s" % frelativepath
-        module = get_module_from_path(fabsolutepath, mod_paths=mod_paths)
+        module = get_module_from_path(fabsolutepath)
         if ('all' in modules or module in modules) and module in installed_modules:
             return module, fabsolutepath, frelativepath, display_path
         return None, None, None, None
@@ -261,22 +267,20 @@ def extend_trans_generate(lang, modules, cr):
                                extra_comments=None, extract_keywords={'_': None}):
         module, fabsolutepath, _, display_path = verified_module_filepaths(fname, path, root)
         extra_comments = extra_comments or []
-        if module:
-            src_file = open(fabsolutepath, 'r')
-            try:
-                #for lineno, message, comments in extract.extract(extract_method, src_file,
-                #                                                 keywords=extract_keywords):
-                for extracted in extract.extract(extract_method, src_file,
-                                                 keywords=extract_keywords):
-                    # Babel 0.9.6 yields lineno, message, comments
-                    # Babel 1.3 yields lineno, message, comments, context
-                    lineno, message, comments = extracted[:3]
-                    push_translation(module, trans_type, display_path, lineno,
-                                     encode(message), comments + extra_comments)
-            except Exception:
-                _logger.exception("Failed to extract terms from %s", fabsolutepath)
-            finally:
-                src_file.close()
+        if not module: return
+        src_file = open(fabsolutepath, 'r')
+        try:
+            for extracted in extract.extract(extract_method, src_file,
+                                             keywords=extract_keywords):
+                # Babel 0.9.6 yields lineno, message, comments
+                # Babel 1.3 yields lineno, message, comments, context
+                lineno, message, comments = extracted[:3]
+                push_translation(module, trans_type, display_path, lineno,
+                                 encode(message), comments + extra_comments)
+        except Exception:
+            _logger.exception("Failed to extract terms from %s", fabsolutepath)
+        finally:
+            src_file.close()
 
     for path in path_list:
         _logger.debug("Scanning files of modules at %s", path)
@@ -299,11 +303,10 @@ def extend_trans_generate(lang, modules, cr):
                                         extra_comments=[WEB_TRANSLATION_COMMENT])
 
     out = []
-    _to_translate.sort()
     # translate strings marked as to be translated
-    for module, source, name, id, type, comments in _to_translate:
+    for module, source, name, id, type, comments in sorted(_to_translate):
         trans = '' if not lang else trans_obj._get_source(cr, uid, name, type, lang, source)
-        out.append([module, type, name, id, source, encode(trans) or '', comments])
+        out.append((module, type, name, id, source, encode(trans) or '', comments))
     return out
 
 import sys


### PR DESCRIPTION
See the bug report #3 for a full scenario of the crash.

The file report_aeroo/translate.py is in fact a monkey-patch of odoo/openerp/tools/translate.py, so I have re-imported the code from v8 with a big copy-paste and re-injected the patch for aeroo in this code. I tested it on odoo v8 with report_aeroo and I can now export the POT file and fr.po file.