### PR TITLE
[FIX] Use report_name when registering an external parser

### DIFF
--- a/report_aeroo/report_xml.py
+++ b/report_aeroo/report_xml.py
@@ -539,7 +539,7 @@ class report_xml(models.Model):
             parser=rml_parse
             vals['auto'] = False
             if vals['parser_state']=='loc' and vals['parser_loc']:
-                parser=self.load_from_file(vals['parser_loc'], vals['name'].lower().replace(' ','_')) or parser
+                parser=self.load_from_file(vals['parser_loc'], vals['report_name'].lower().replace(' ','_')) or parser
             elif vals['parser_state']=='def' and vals['parser_def']:
                 parser=self.load_from_source(vals['parser_def']) or parser
             res_id = super(report_xml, self).create(vals)


### PR DESCRIPTION
Since the name field is human readable it can contain non ascii characters in foreign languages that will break the import of the parser
