### PR TITLE
Change separator to xpath expressions

### DIFF
--- a/report_aeroo/installer.xml
+++ b/report_aeroo/installer.xml
@@ -20,7 +20,7 @@
                         <button special="cancel" string="Close" class="oe_link"/>
                     </footer>
                 </footer>
-                <separator string="title" position="replace">
+                <xpath expr="//separator" position="replace">
                     <p class="oe_grey">
                         Aeroo Reports for OpenERP is a comprehensive reporting engine based on Aeroo Library.
                     </p>
@@ -32,7 +32,7 @@
                           <field name="link" widget="url"/>
                         </group>
                     </group>
-                </separator>
+                </xpath>
           </data>
       </field>
     </record>
@@ -73,7 +73,7 @@
                         <button special="cancel" string="Close" class="oe_link"/>
                     </footer>
                 </footer>
-                <separator string="title" position="replace">
+                <xpath expr="//separator" position="replace">
                     <p class="oe_grey">
                         Configure Aeroo Reports connection to DOCS service and test document conversion.
                     </p>
@@ -108,7 +108,7 @@
                       <field name="state" invisible="1"/>
                     </group>
                   </group>
-                </separator>
+                </xpath>
           </data>
       </field>
     </record>


### PR DESCRIPTION
By doing so this module will be fully compatible with Odoo 9.
Odoo 9 does not longer allow identifying items with string="stringName" so this needed a decent xpath expr.
