### PR TITLE
[FIX] logger call interpreted as context

### DIFF
--- a/report_aeroo/report_aeroo.py
+++ b/report_aeroo/report_aeroo.py
@@ -151,7 +151,7 @@ class Aeroo_report(report_sxw):
         return enabled == 'True' and True or False
 
     def logger(self, message, level=logging.DEBUG):
-        logger.log(level, message, exc_info=1)
+        logger.log(level, message)
 
     def __init__(self, cr, name, table, rml=False, parser=False, header=True, store=False):
         super(Aeroo_report, self).__init__(name, table, rml, parser, header, store)

--- a/report_aeroo/translate.py
+++ b/report_aeroo/translate.py
@@ -132,10 +132,10 @@ def extend_trans_generate(lang, modules, cr):
                 _logger.error("name error in %s: %s", xml_name, str(exc))
                 continue
             objmodel = registry.get(obj.model)
-            if (objmodel is None or field_name not in objmodel._columns
+            if (objmodel is None or field_name not in objmodel._fields
                     or not objmodel._translate):
                 continue
-            field_def = objmodel._columns[field_name]
+            field_def = objmodel._fields[field_name]
 
             name = "%s,%s" % (encode(obj.model), field_name)
             push_translation(module, 'field', name, 0, encode(field_def.string))
@@ -143,7 +143,7 @@ def extend_trans_generate(lang, modules, cr):
             if field_def.help:
                 push_translation(module, 'help', name, 0, encode(field_def.help))
 
-            if field_def.translate:
+            if getattr(field_def, 'translate', None):
                 ids = objmodel.search(cr, uid, [])
                 obj_values = objmodel.read(cr, uid, ids, [field_name])
                 for obj_value in obj_values:


### PR DESCRIPTION
The function call of logger cause error in fuction onchange_template_id() of mail.compose.message (at least), because the last variable (exc_info) is interpreted as context.
Removing it the error is gone.