### PR TITLE
[FIX] currency to text call

### DIFF
--- a/report_aeroo/report_parser.py
+++ b/report_aeroo/report_parser.py
@@ -176,7 +176,7 @@ class ReportAerooAbstract(models.AbstractModel):
             'time':     time,
             'asarray':  self._asarray,
             'average':  self._average,
-            'currency_to_text':self.currency_to_text,
+            'currency_to_text':self._currency_to_text,
             
             '__filter': self.__filter, # Don't use in the report template!
             'getLang':  self._get_lang,


### PR DESCRIPTION
As far as I understand on this [line](https://github.com/aeroo/aeroo_reports/blob/11.0/report_aeroo/report_parser.py#L179) the underscore is missing so that it calls [this function](https://github.com/aeroo/aeroo_reports/blob/11.0/report_aeroo/report_parser.py#L70)

Without this fix I get "`AttributeError: 'report.sample_report' object has no attribute 'currency_to_text'`" error while trying to print any report.
